### PR TITLE
Support for Arduino Mega 2560

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ ESP32 may need a logic level converter from 5V to 3.3V.
 
 Additionally, to use uninverted sbus FrSky signal pin, please refer to [Oscar Liang's post](https://oscarliang.com/uninverted-sbus-smart-port-frsky-receivers/).
 
+## Using SBUS on Arduino Mega 2560
+Since SBUS uses inverted serial logic, you need to connect the receivers and servors through a signal inverter circuit as explained [here](https://dev.px4.io/en/tutorials/linux_sbus.html). Basically, you need to use an NPN transistor with the following connections:
+* connect SBUS signal to the base of the NPN transistor through a 1K resistor
+* connect GND of the Arduino board to the emitter of the transistor
+* connect Arduino operating voltage (5V for Mega 2560) to the collector of the transistor through a 10K resistor
+* connect RX port of the used Arduino serial port to the collector of the transistor
+
 # Description
 SBUS is a protocol for RC receivers to send commands to servos. Unlike PWM, SBUS uses a bus architecture where a single signal line can be connected up to 16 servos with each receiving a unique command. SBUS capable servos are required; each can be programmed with a unique address (Channel 0 - 15) using an SBUS servo programmer. Advantages of SBUS include the reduction of wiring clutter and ease of parsing commands from RC receivers.
 

--- a/src/SBUS.cpp
+++ b/src/SBUS.cpp
@@ -5,19 +5,19 @@ brian.taylor@bolderflight.com
 
 Copyright (c) 2016 Bolder Flight Systems
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-and associated documentation files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, 
-sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or 
+The above copyright notice and this permission notice shall be included in all copies or
 substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
-BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
@@ -50,15 +50,17 @@ void SBUS::begin()
 	#if defined(__MK20DX128__) || defined(__MK20DX256__)  // Teensy 3.0 || Teensy 3.1/3.2
 		_bus->begin(_sbusBaud,SERIAL_8E1_RXINV_TXINV);
 		SERIALPORT = _bus;
-	#elif defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__)  // Teensy 3.5 || Teensy 3.6 || Teensy LC 
+	#elif defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__)  // Teensy 3.5 || Teensy 3.6 || Teensy LC
 		_bus->begin(_sbusBaud,SERIAL_8E2_RXINV_TXINV);
 	#elif defined(STM32L496xx) || defined(STM32L476xx) || defined(STM32L433xx) || defined(STM32L432xx)  // STM32L4
 		_bus->begin(_sbusBaud,SERIAL_SBUS);
 	#elif defined(_BOARD_MAPLE_MINI_H_) // Maple Mini
 		_bus->begin(_sbusBaud,SERIAL_8E2);
 	#elif defined(ESP32)                // ESP32
-        	_bus->begin(_sbusBaud,SERIAL_8E2);
-	#endif
+        _bus->begin(_sbusBaud,SERIAL_8E2);
+  #elif defined(__AVR_ATmega2560__)  // Arduino Mega 2560
+        _bus->begin(_sbusBaud, SERIAL_8E2);
+  #endif
 }
 
 /* read the SBUS data */
@@ -97,7 +99,7 @@ bool SBUS::read(uint16_t* channels, bool* failsafe, bool* lostFrame)
     	// failsafe state
     	if (_payload[22] & _sbusFailSafe) {
       		*failsafe = true;
-    	} 
+    	}
     	else{
       		*failsafe = false;
     	}
@@ -137,7 +139,7 @@ void SBUS::write(uint16_t* channels)
 	static uint8_t packet[25];
 	/* assemble the SBUS packet */
 	// SBUS header
-	packet[0] = _sbusHeader; 
+	packet[0] = _sbusHeader;
 	// 16 channels of 11 bit data
 	if (channels) {
 		packet[1] = (uint8_t) ((channels[0] & 0x07FF));
@@ -153,7 +155,7 @@ void SBUS::write(uint16_t* channels)
 		packet[11] = (uint8_t) ((channels[7] & 0x07FF)>>3);
 		packet[12] = (uint8_t) ((channels[8] & 0x07FF));
 		packet[13] = (uint8_t) ((channels[8] & 0x07FF)>>8 | (channels[9] & 0x07FF)<<3);
-		packet[14] = (uint8_t) ((channels[9] & 0x07FF)>>5 | (channels[10] & 0x07FF)<<6);  
+		packet[14] = (uint8_t) ((channels[9] & 0x07FF)>>5 | (channels[10] & 0x07FF)<<6);
 		packet[15] = (uint8_t) ((channels[10] & 0x07FF)>>2);
 		packet[16] = (uint8_t) ((channels[10] & 0x07FF)>>10 | (channels[11] & 0x07FF)<<1);
 		packet[17] = (uint8_t) ((channels[11] & 0x07FF)>>7 | (channels[12] & 0x07FF)<<4);
@@ -168,7 +170,7 @@ void SBUS::write(uint16_t* channels)
 	// footer
 	packet[24] = _sbusFooter;
 	#if defined(__MK20DX128__) || defined(__MK20DX256__) // Teensy 3.0 || Teensy 3.1/3.2
-		// use ISR to send byte at a time, 
+		// use ISR to send byte at a time,
 		// 130 us between bytes to emulate 2 stop bits
 		noInterrupts();
 		memcpy(&PACKET,&packet,sizeof(packet));
@@ -292,7 +294,7 @@ SBUS::~SBUS()
 }
 
 /* parse the SBUS data */
-bool SBUS::parse() 
+bool SBUS::parse()
 {
 	// reset the parser state if too much time has passed
 	static elapsedMicros _sbusTime = 0;

--- a/src/SBUS.h
+++ b/src/SBUS.h
@@ -5,19 +5,19 @@ brian.taylor@bolderflight.com
 
 Copyright (c) 2016 Bolder Flight Systems
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-and associated documentation files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, 
-sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or 
+The above copyright notice and this permission notice shall be included in all copies or
 substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
-BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
@@ -27,14 +27,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 #include "Arduino.h"
 #include "elapsedMillis.h"
 
-/* 
+/*
 * Hardware Serial Supported:
-* Teensy 3.0 || Teensy 3.1/3.2 || Teensy 3.5 || Teensy 3.6 || Teensy LC  || STM32L4 || Maple Mini
+* Teensy 3.0 || Teensy 3.1/3.2 || Teensy 3.5 || Teensy 3.6 || Teensy LC  || STM32L4 || Maple Mini || Arduino Mega 2560
 */
 #if defined(__MK20DX128__) 	|| defined(__MK20DX256__) || defined(__MK64FX512__)	\
 	|| defined(__MK66FX1M0__) || defined(__MKL26Z64__) 	|| defined(STM32L496xx)		\
 	|| defined(STM32L476xx) 	|| defined(STM32L433xx) 	|| defined(STM32L432xx)		\
-	|| defined(_BOARD_MAPLE_MINI_H_)
+	|| defined(_BOARD_MAPLE_MINI_H_) || defined(__AVR_ATmega2560__)
 #endif
 
 class SBUS{
@@ -62,7 +62,7 @@ class SBUS{
 		const uint32_t SBUS_TIMEOUT_US = 7000;
 		uint8_t _parserState, _prevByte = _sbusFooter, _curByte;
 		static const uint8_t _payloadSize = 24;
-		uint8_t _payload[_payloadSize];		
+		uint8_t _payload[_payloadSize];
 		const uint8_t _sbusLostFrame = 0x04;
 		const uint8_t _sbusFailSafe = 0x08;
 		const uint16_t _defaultMin = 172;


### PR DESCRIPTION
Added codes and instructions for using SBUS with Arduino Mega 2560. Tested and verified to work with a Futaba R30001SB receiver. This needs a signal inverter circuit, and the instructions for the circuit also are added to the readme file.