### PR TITLE
Added signed readS function

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ if(x8r.read(&channels[0], &failSafe, &lostFrame)){
 }
 ```
 
+**bool readS(int16_t&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)**
+*readS(int16_t&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)* duplicates teh behaviour of *read(int16_t&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)* except that *channels[0-15]* are returned as signed integer offset from a defined midpoint value (the function to modify these midpoints is described below). For example, placing the following code in the loop function will print the signed shifted value of *channel 0* every time a valid SBUS packet is received.
+
+```C++
+int16_t channels[16];
+bool failSafe;
+bool lostFrame;
+
+if(x8r.read(&channels[0], &failSafe, &lostFrame)){
+	Serial.println(channels[0]);
+}
+```
+
 **bool readCal(float&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)**
 *readCal(float&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)* reads data from the SBUS receiver and parses the SBUS packet. The data from *channels[0-15]* is calibrated to a +/- 1.0 float value assuming a linear relationship based on the minimum and maximum value, or endpoints, for each channel. By default these are set to 172 and 1811, respectively, using FrSky set to 0-100%. The functions described below describe how to modify these endpoints. This is useful if you have endpoints setup differently in your transmitter, but would still like to map to a +/- 1.0 value. Following scaling based on endpoint values, the channels data can optionally be calibrated via polynomial evaluation. The functions described below describe how to setup these polynomials. This could be useful for cases where you would like to receive input data in terms of resulting control surface position for a fixed wing aircraft instead of +/- 1.0 scaled values.
 
@@ -124,6 +137,12 @@ This sets the endpoints for readCal and writeCal for the given channel number. B
 
 **void getEndPoints(uint8_t channel,uint16_t&ast; min,uint16_t&ast; max)**
 This method retrieves the endpoints for the given channel number.
+
+**void setMidPoint(uint8_t channel,uint16_t mid)**
+This sets the midpoint for readS for the given channel number. By default midpoints are set to 992.
+
+**void getMidPoint(uint8_t channel,uint16_t&ast; mid)**
+This method retrieves the midpoint for the given channel number.
 
 **void setReadCal(uint8_t channel,float&ast; coeff,uint8_t len)**
 This method sets a polynomial for the given channel used by the *readCal* method. The coefficients should be an array of length *len* given in descending order. For example, *float cal[2] = {2,0}* would apply a scale factor of two, with zero bias, to the *readCal* data from the given channel resulting in data ranging from +/- 2.0 instead of +/- 1.0.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ int16_t channels[16];
 bool failSafe;
 bool lostFrame;
 
-if(x8r.read(&channels[0], &failSafe, &lostFrame)){
+if(x8r.readS(&channels[0], &failSafe, &lostFrame)){
 	Serial.println(channels[0]);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ if(x8r.read(&channels[0], &failSafe, &lostFrame)){
 ```
 
 **bool readS(int16_t&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)**
-*readS(int16_t&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)* duplicates teh behaviour of *read(int16_t&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)* except that *channels[0-15]* are returned as signed integer offset from a defined midpoint value (the function to modify these midpoints is described below). For example, placing the following code in the loop function will print the signed shifted value of *channel 0* every time a valid SBUS packet is received.
+*readS(int16_t&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)* duplicates the behaviour of *read(int16_t&ast; channels, bool&ast; failsafe, bool&ast; lostFrame)* except that *channels[0-15]* are now returned as signed integer offsets from a defined midpoint value (the function to modify these midpoints is described below). For example, placing the following code in the loop function will print the signed shifted value of *channel 0* every time a valid SBUS packet is received.
 
 ```C++
 int16_t channels[16];

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This gork of teh bolderflight/SBUS Arduino library adds a *readS()* function that returns signed integer values and associated *setMidPoint()* and *getMidPoint* functions.  Othwise teh information below is taken from the bolderflight repo.
+
 # SBUS
 Arduino library for communicating with SBUS receivers and servos. SBUS uses inverted serial logic with a baud rate of 100000, 8 data bits, even parity bit, and 2 stop bits. This library works with Teensy 3.x and LC devices, the [STM32L4](https://github.com/simondlevy/grumpyoldpizza), the Maple Mini, and ESP32 (see below). If you have other Arduino devices or port this library, I would appreciate pull requests to update this to work with as many devices as possible.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This gork of teh bolderflight/SBUS Arduino library adds a *readS()* function that returns signed integer values and associated *setMidPoint()* and *getMidPoint* functions.  Othwise teh information below is taken from the bolderflight repo.
+This fork of the bolderflight/SBUS Arduino library adds a *readS()* function that returns signed integer values and associated *setMidPoint()* and *getMidPoint* functions.  Othwise the information below is taken from the bolderflight repo (i.e. 'our' is not mine - it's theirs).
 
 # SBUS
 Arduino library for communicating with SBUS receivers and servos. SBUS uses inverted serial logic with a baud rate of 100000, 8 data bits, even parity bit, and 2 stop bits. This library works with Teensy 3.x and LC devices, the [STM32L4](https://github.com/simondlevy/grumpyoldpizza), the Maple Mini, and ESP32 (see below). If you have other Arduino devices or port this library, I would appreciate pull requests to update this to work with as many devices as possible.

--- a/src/SBUS.cpp
+++ b/src/SBUS.cpp
@@ -5,23 +5,23 @@ brian.taylor@bolderflight.com
 
 Copyright (c) 2016 Bolder Flight Systems
 
-With readS and associated midpoint functions added by Ian Smith, ian@astounding.org.uk
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software
-and associated documentation files (the "Software"), to deal in the Software without restriction,
-including without limitation the rights to use, copy, modify, merge, publish, distribute,
-sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+and associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, 
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is 
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or
+The above copyright notice and this permission notice shall be included in all copies or 
 substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
-BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
+
+// With readS and associated midpoint functions added by Ian Smith, ian@astounding.org.uk
 
 #include "SBUS.h"
 
@@ -53,17 +53,13 @@ void SBUS::begin()
 	#if defined(__MK20DX128__) || defined(__MK20DX256__)  // Teensy 3.0 || Teensy 3.1/3.2
 		_bus->begin(_sbusBaud,SERIAL_8E1_RXINV_TXINV);
 		SERIALPORT = _bus;
-	#elif defined(__IMXRT1052__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__)  // Teensy 4.0 || Teensy 3.5 || Teensy 3.6 || Teensy LC
+	#elif defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__)  // Teensy 3.5 || Teensy 3.6 || Teensy LC 
 		_bus->begin(_sbusBaud,SERIAL_8E2_RXINV_TXINV);
 	#elif defined(STM32L496xx) || defined(STM32L476xx) || defined(STM32L433xx) || defined(STM32L432xx)  // STM32L4
 		_bus->begin(_sbusBaud,SERIAL_SBUS);
 	#elif defined(_BOARD_MAPLE_MINI_H_) // Maple Mini
 		_bus->begin(_sbusBaud,SERIAL_8E2);
-	#elif defined(ESP32)                // ESP32
-        _bus->begin(_sbusBaud,SERIAL_8E2);
-  #elif defined(__AVR_ATmega2560__)  // Arduino Mega 2560
-        _bus->begin(_sbusBaud, SERIAL_8E2);
-  #endif
+	#endif
 }
 
 /* read the SBUS data */
@@ -102,7 +98,7 @@ bool SBUS::read(uint16_t* channels, bool* failsafe, bool* lostFrame)
     	// failsafe state
     	if (_payload[22] & _sbusFailSafe) {
       		*failsafe = true;
-    	}
+    	} 
     	else{
       		*failsafe = false;
     	}
@@ -115,29 +111,29 @@ bool SBUS::read(uint16_t* channels, bool* failsafe, bool* lostFrame)
 	}
 }
 
-/* read the SBUS data and return it as offset from defined mid value*/
+// read the SBUS data and return it as offset from defined mid value
 bool SBUS::readS(int16_t* channels, bool* failsafe, bool* lostFrame)
 {
 	// parse the SBUS packet
 	if (parse()) {
 		if (channels) {
 			// 16 channels of 11 bit data
-		  channels[0]  = (uint16_t) (((_payload[0]    |_payload[1] <<8)                     & 0x07FF) - _sbusMid[0]);
-		  channels[1]  = (uint16_t) (((_payload[1]>>3 |_payload[2] <<5)                     & 0x07FF) - _sbusMid[1]);
-		  channels[2]  = (uint16_t) (((_payload[2]>>6 |_payload[3] <<2 |_payload[4]<<10)    & 0x07FF) - _sbusMid[2]);
-		  channels[3]  = (uint16_t) (((_payload[4]>>1 |_payload[5] <<7)                     & 0x07FF) - _sbusMid[3]);
-		  channels[4]  = (uint16_t) (((_payload[5]>>4 |_payload[6] <<4)                     & 0x07FF) - _sbusMid[4]);
-		  channels[5]  = (uint16_t) (((_payload[6]>>7 |_payload[7] <<1 |_payload[8]<<9)     & 0x07FF) - _sbusMid[5]);
-		  channels[6]  = (uint16_t) (((_payload[8]>>2 |_payload[9] <<6)                     & 0x07FF) - _sbusMid[6]);
-		  channels[7]  = (uint16_t) (((_payload[9]>>5 |_payload[10]<<3)                     & 0x07FF) - _sbusMid[7]);
-		  channels[8]  = (uint16_t) (((_payload[11]   |_payload[12]<<8)                     & 0x07FF) - _sbusMid[8]);
-		  channels[9]  = (uint16_t) (((_payload[12]>>3|_payload[13]<<5)                     & 0x07FF) - _sbusMid[9]);
-		  channels[10] = (uint16_t) (((_payload[13]>>6|_payload[14]<<2 |_payload[15]<<10)   & 0x07FF) - _sbusMid[10]);
-		  channels[11] = (uint16_t) (((_payload[15]>>1|_payload[16]<<7)                     & 0x07FF) - _sbusMid[11]);
-		  channels[12] = (uint16_t) (((_payload[16]>>4|_payload[17]<<4)                     & 0x07FF) - _sbusMid[12]);
-		  channels[13] = (uint16_t) (((_payload[17]>>7|_payload[18]<<1 |_payload[19]<<9)    & 0x07FF) - _sbusMid[13]);
-		  channels[14] = (uint16_t) (((_payload[19]>>2|_payload[20]<<6)                     & 0x07FF) - _sbusMid[14]);
-		  channels[15] = (uint16_t) (((_payload[20]>>5|_payload[21]<<3)                     & 0x07FF) - _sbusMid[15]);
+			channels[0]  = (int16_t) (((_payload[0]    |_payload[1] <<8)                     & 0x07FF) - _sbusMid[0]);
+			channels[1]  = (int16_t) (((_payload[1]>>3 |_payload[2] <<5)                     & 0x07FF) - _sbusMid[1]);
+			channels[2]  = (int16_t) (((_payload[2]>>6 |_payload[3] <<2 |_payload[4]<<10) 	  & 0x07FF) - _sbusMid[2]);
+			channels[3]  = (int16_t) (((_payload[4]>>1 |_payload[5] <<7)                     & 0x07FF) - _sbusMid[3]);
+			channels[4]  = (int16_t) (((_payload[5]>>4 |_payload[6] <<4)                     & 0x07FF) - _sbusMid[4]);
+			channels[5]  = (int16_t) (((_payload[6]>>7 |_payload[7] <<1 |_payload[8]<<9)     & 0x07FF) - _sbusMid[5]);
+			channels[6]  = (int16_t) (((_payload[8]>>2 |_payload[9] <<6)                     & 0x07FF) - _sbusMid[6]);
+			channels[7]  = (int16_t) (((_payload[9]>>5 |_payload[10]<<3)                     & 0x07FF) - _sbusMid[7]);
+			channels[8]  = (int16_t) (((_payload[11]   |_payload[12]<<8)                     & 0x07FF) - _sbusMid[8]);
+			channels[9]  = (int16_t) (((_payload[12]>>3|_payload[13]<<5)                     & 0x07FF) - _sbusMid[9]);
+			channels[10] = (int16_t) (((_payload[13]>>6|_payload[14]<<2 |_payload[15]<<10)   & 0x07FF) - _sbusMid[10]);
+			channels[11] = (int16_t) (((_payload[15]>>1|_payload[16]<<7)                     & 0x07FF) - _sbusMid[11]);
+			channels[12] = (int16_t) (((_payload[16]>>4|_payload[17]<<4)                     & 0x07FF) - _sbusMid[12]);
+			channels[13] = (int16_t) (((_payload[17]>>7|_payload[18]<<1 |_payload[19]<<9)    & 0x07FF) - _sbusMid[13]);
+			channels[14] = (int16_t) (((_payload[19]>>2|_payload[20]<<6)                     & 0x07FF) - _sbusMid[14]);
+			channels[15] = (int16_t) (((_payload[20]>>5|_payload[21]<<3)                     & 0x07FF) - _sbusMid[15]);
 		}
 		if (lostFrame) {
     	// count lost frames
@@ -151,7 +147,7 @@ bool SBUS::readS(int16_t* channels, bool* failsafe, bool* lostFrame)
     	// failsafe state
     	if (_payload[22] & _sbusFailSafe) {
       		*failsafe = true;
-    	}
+    	} 
     	else{
       		*failsafe = false;
     	}
@@ -163,6 +159,7 @@ bool SBUS::readS(int16_t* channels, bool* failsafe, bool* lostFrame)
 		return false;
 	}
 }
+
 
 /* read the SBUS data and calibrate it to +/- 1 */
 bool SBUS::readCal(float* calChannels, bool* failsafe, bool* lostFrame)
@@ -191,7 +188,7 @@ void SBUS::write(uint16_t* channels)
 	static uint8_t packet[25];
 	/* assemble the SBUS packet */
 	// SBUS header
-	packet[0] = _sbusHeader;
+	packet[0] = _sbusHeader; 
 	// 16 channels of 11 bit data
 	if (channels) {
 		packet[1] = (uint8_t) ((channels[0] & 0x07FF));
@@ -207,7 +204,7 @@ void SBUS::write(uint16_t* channels)
 		packet[11] = (uint8_t) ((channels[7] & 0x07FF)>>3);
 		packet[12] = (uint8_t) ((channels[8] & 0x07FF));
 		packet[13] = (uint8_t) ((channels[8] & 0x07FF)>>8 | (channels[9] & 0x07FF)<<3);
-		packet[14] = (uint8_t) ((channels[9] & 0x07FF)>>5 | (channels[10] & 0x07FF)<<6);
+		packet[14] = (uint8_t) ((channels[9] & 0x07FF)>>5 | (channels[10] & 0x07FF)<<6);  
 		packet[15] = (uint8_t) ((channels[10] & 0x07FF)>>2);
 		packet[16] = (uint8_t) ((channels[10] & 0x07FF)>>10 | (channels[11] & 0x07FF)<<1);
 		packet[17] = (uint8_t) ((channels[11] & 0x07FF)>>7 | (channels[12] & 0x07FF)<<4);
@@ -222,14 +219,14 @@ void SBUS::write(uint16_t* channels)
 	// footer
 	packet[24] = _sbusFooter;
 	#if defined(__MK20DX128__) || defined(__MK20DX256__) // Teensy 3.0 || Teensy 3.1/3.2
-		// use ISR to send byte at a time,
+		// use ISR to send byte at a time, 
 		// 130 us between bytes to emulate 2 stop bits
 		noInterrupts();
 		memcpy(&PACKET,&packet,sizeof(packet));
 		interrupts();
 		serialTimer.priority(255);
 		serialTimer.begin(sendByte,130);
-	#elif defined(__IMXRT1052__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__) || defined(STM32L496xx) || defined(STM32L476xx) || defined(STM32L433xx) || defined(STM32L432xx) || defined(_BOARD_MAPLE_MINI_H_)  // Teensy 3.5 || Teensy 3.6 || Teensy LC || STM32L4 || Maple Mini
+	#elif defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__) || defined(STM32L496xx) || defined(STM32L476xx) || defined(STM32L433xx) || defined(STM32L432xx) || defined(_BOARD_MAPLE_MINI_H_)  // Teensy 3.5 || Teensy 3.6 || Teensy LC || STM32L4 || Maple Mini
 		// write packet
 		_bus->write(packet,25);
 	#endif
@@ -358,7 +355,7 @@ SBUS::~SBUS()
 }
 
 /* parse the SBUS data */
-bool SBUS::parse()
+bool SBUS::parse() 
 {
 	// reset the parser state if too much time has passed
 	static elapsedMicros _sbusTime = 0;

--- a/src/SBUS.cpp
+++ b/src/SBUS.cpp
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SO
 */
 
 // with bool SBUS::readS(int16_t* channels, bool* failsafe, bool* lostFrame)
-// added by Ian SMith ian@astounding.org.uk
+// added by Ian Smith ian@astounding.org.uk
 
 #include "SBUS.h"
 
@@ -103,7 +103,7 @@ bool SBUS::read(uint16_t* channels, bool* failsafe, bool* lostFrame)
     	// failsafe state
     	if (_payload[22] & _sbusFailSafe) {
       		*failsafe = true;
-    	} 
+    	}
     	else{
       		*failsafe = false;
     	}
@@ -116,7 +116,7 @@ bool SBUS::read(uint16_t* channels, bool* failsafe, bool* lostFrame)
 	}
 }
 
-// read the SBUS data and return it as offset from defined mid value
+/* read signed SBUS data */
 bool SBUS::readS(int16_t* channels, bool* failsafe, bool* lostFrame)
 {
 	// parse the SBUS packet
@@ -152,7 +152,7 @@ bool SBUS::readS(int16_t* channels, bool* failsafe, bool* lostFrame)
     	// failsafe state
     	if (_payload[22] & _sbusFailSafe) {
       		*failsafe = true;
-    	} 
+    	}
     	else{
       		*failsafe = false;
     	}

--- a/src/SBUS.cpp
+++ b/src/SBUS.cpp
@@ -5,23 +5,24 @@ brian.taylor@bolderflight.com
 
 Copyright (c) 2016 Bolder Flight Systems
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-and associated documentation files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, 
-sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or 
+The above copyright notice and this permission notice shall be included in all copies or
 substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING 
-BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND 
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, 
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-// With readS and associated midpoint functions added by Ian Smith, ian@astounding.org.uk
+// with bool SBUS::readS(int16_t* channels, bool* failsafe, bool* lostFrame)
+// added by Ian SMith ian@astounding.org.uk
 
 #include "SBUS.h"
 
@@ -53,14 +54,19 @@ void SBUS::begin()
 	#if defined(__MK20DX128__) || defined(__MK20DX256__)  // Teensy 3.0 || Teensy 3.1/3.2
 		_bus->begin(_sbusBaud,SERIAL_8E1_RXINV_TXINV);
 		SERIALPORT = _bus;
-	#elif defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__)  // Teensy 3.5 || Teensy 3.6 || Teensy LC 
+	#elif defined(__IMXRT1052__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__)  // Teensy 4.0 || Teensy 3.5 || Teensy 3.6 || Teensy LC
 		_bus->begin(_sbusBaud,SERIAL_8E2_RXINV_TXINV);
 	#elif defined(STM32L496xx) || defined(STM32L476xx) || defined(STM32L433xx) || defined(STM32L432xx)  // STM32L4
 		_bus->begin(_sbusBaud,SERIAL_SBUS);
 	#elif defined(_BOARD_MAPLE_MINI_H_) // Maple Mini
 		_bus->begin(_sbusBaud,SERIAL_8E2);
-	#endif
+	#elif defined(ESP32)                // ESP32
+        _bus->begin(_sbusBaud,SERIAL_8E2);
+  #elif defined(__AVR_ATmega2560__)  // Arduino Mega 2560
+        _bus->begin(_sbusBaud, SERIAL_8E2);
+  #endif
 }
+
 
 /* read the SBUS data */
 bool SBUS::read(uint16_t* channels, bool* failsafe, bool* lostFrame)
@@ -160,7 +166,6 @@ bool SBUS::readS(int16_t* channels, bool* failsafe, bool* lostFrame)
 	}
 }
 
-
 /* read the SBUS data and calibrate it to +/- 1 */
 bool SBUS::readCal(float* calChannels, bool* failsafe, bool* lostFrame)
 {
@@ -188,7 +193,7 @@ void SBUS::write(uint16_t* channels)
 	static uint8_t packet[25];
 	/* assemble the SBUS packet */
 	// SBUS header
-	packet[0] = _sbusHeader; 
+	packet[0] = _sbusHeader;
 	// 16 channels of 11 bit data
 	if (channels) {
 		packet[1] = (uint8_t) ((channels[0] & 0x07FF));
@@ -204,7 +209,7 @@ void SBUS::write(uint16_t* channels)
 		packet[11] = (uint8_t) ((channels[7] & 0x07FF)>>3);
 		packet[12] = (uint8_t) ((channels[8] & 0x07FF));
 		packet[13] = (uint8_t) ((channels[8] & 0x07FF)>>8 | (channels[9] & 0x07FF)<<3);
-		packet[14] = (uint8_t) ((channels[9] & 0x07FF)>>5 | (channels[10] & 0x07FF)<<6);  
+		packet[14] = (uint8_t) ((channels[9] & 0x07FF)>>5 | (channels[10] & 0x07FF)<<6);
 		packet[15] = (uint8_t) ((channels[10] & 0x07FF)>>2);
 		packet[16] = (uint8_t) ((channels[10] & 0x07FF)>>10 | (channels[11] & 0x07FF)<<1);
 		packet[17] = (uint8_t) ((channels[11] & 0x07FF)>>7 | (channels[12] & 0x07FF)<<4);
@@ -355,7 +360,7 @@ SBUS::~SBUS()
 }
 
 /* parse the SBUS data */
-bool SBUS::parse() 
+bool SBUS::parse()
 {
 	// reset the parser state if too much time has passed
 	static elapsedMicros _sbusTime = 0;

--- a/src/SBUS.cpp
+++ b/src/SBUS.cpp
@@ -67,7 +67,6 @@ void SBUS::begin()
   #endif
 }
 
-
 /* read the SBUS data */
 bool SBUS::read(uint16_t* channels, bool* failsafe, bool* lostFrame)
 {
@@ -224,14 +223,14 @@ void SBUS::write(uint16_t* channels)
 	// footer
 	packet[24] = _sbusFooter;
 	#if defined(__MK20DX128__) || defined(__MK20DX256__) // Teensy 3.0 || Teensy 3.1/3.2
-		// use ISR to send byte at a time, 
+		// use ISR to send byte at a time,
 		// 130 us between bytes to emulate 2 stop bits
 		noInterrupts();
 		memcpy(&PACKET,&packet,sizeof(packet));
 		interrupts();
 		serialTimer.priority(255);
 		serialTimer.begin(sendByte,130);
-	#elif defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__) || defined(STM32L496xx) || defined(STM32L476xx) || defined(STM32L433xx) || defined(STM32L432xx) || defined(_BOARD_MAPLE_MINI_H_)  // Teensy 3.5 || Teensy 3.6 || Teensy LC || STM32L4 || Maple Mini
+	#elif defined(__IMXRT1052__) || defined(__MK64FX512__) || defined(__MK66FX1M0__) || defined(__MKL26Z64__) || defined(STM32L496xx) || defined(STM32L476xx) || defined(STM32L433xx) || defined(STM32L432xx) || defined(_BOARD_MAPLE_MINI_H_)  // Teensy 3.5 || Teensy 3.6 || Teensy LC || STM32L4 || Maple Mini
 		// write packet
 		_bus->write(packet,25);
 	#endif

--- a/src/SBUS.h
+++ b/src/SBUS.h
@@ -5,6 +5,8 @@ brian.taylor@bolderflight.com
 
 Copyright (c) 2016 Bolder Flight Systems
 
+With readS and associated midpoint functions added by Ian Smith, ian@astounding.org.uk
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software
 and associated documentation files (the "Software"), to deal in the Software without restriction,
 including without limitation the rights to use, copy, modify, merge, publish, distribute,
@@ -42,11 +44,14 @@ class SBUS{
 		SBUS(HardwareSerial& bus);
 		void begin();
 		bool read(uint16_t* channels, bool* failsafe, bool* lostFrame);
+		bool readS(int16_t* channels, bool* failsafe, bool* lostFrame);
 		bool readCal(float* calChannels, bool* failsafe, bool* lostFrame);
 		void write(uint16_t* channels);
 		void writeCal(float *channels);
 		void setEndPoints(uint8_t channel,uint16_t min,uint16_t max);
 		void getEndPoints(uint8_t channel,uint16_t *min,uint16_t *max);
+		void setMidPoint(uint8_t channel,uint16_t mid);
+		void getMidPoint(uint8_t channel,uint16_t *mid);
 		void setReadCal(uint8_t channel,float *coeff,uint8_t len);
 		void getReadCal(uint8_t channel,float *coeff,uint8_t len);
 		void setWriteCal(uint8_t channel,float *coeff,uint8_t len);
@@ -67,8 +72,10 @@ class SBUS{
 		const uint8_t _sbusFailSafe = 0x08;
 		const uint16_t _defaultMin = 172;
 		const uint16_t _defaultMax = 1811;
+		const uint16_t _defaultMid = 992;
 		uint16_t _sbusMin[_numChannels];
 		uint16_t _sbusMax[_numChannels];
+		uint16_t _sbusMid[_numChannels];
 		float _sbusScale[_numChannels];
 		float _sbusBias[_numChannels];
 		float **_readCoeff, **_writeCoeff;


### PR DESCRIPTION
Hi, thanks for the SBUS library.

In my application I wanted to work with integer data, but offset from midpoint of the channel, so not as much processed as readCal() but not as raw as read().  I guess that makes it half-baked.

This can obviously be done outside the library, but it seemed neater inside.  I have created readS() (not sure if that's 'read signed' or 'read shifted') that returns signed integer values of offset from defined midpoints, and the associated setMidPoint() and getMidPoint() functions.

There is no writeS() because I have no SBUS-aware hardware to test it with.