### PR TITLE
Add support for Atmel ATmega 328p and 32u4 and unsupported message

### DIFF
--- a/src/SBUS.cpp
+++ b/src/SBUS.cpp
@@ -64,10 +64,12 @@ void SBUS::begin()
 		_bus->begin(_sbusBaud,SERIAL_8E2);
 	#elif defined(ESP32)              	// ESP32
     _bus->begin(_sbusBaud,SERIAL_8E2);
-  #elif defined(__AVR_ATmega2560__)		// Arduino Mega 2560
+  #elif defined(__AVR_ATmega2560__) || defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)		// Arduino Mega 2560, 328P or 32u4
     _bus->begin(_sbusBaud, SERIAL_8E2);
 	#elif defined(ARDUINO_SAMD_ZERO)		// Adafruit Feather M0
 		_bus->begin(_sbusBaud, SERIAL_8E2);
+	#else
+		#error unsupported device
   #endif
 }
 


### PR DESCRIPTION
Tested SBUS reception from a frsky x4r on 328p and 32u4 and it works beautifully.
I didn't test sending anything though. Maybe this is still enough to add support for them?