### PR TITLE
Moved ESP32 pin specification from constructor to Begin()

### DIFF
--- a/examples/SBUS_example/SBUS_example.ino
+++ b/examples/SBUS_example/SBUS_example.ino
@@ -52,7 +52,7 @@ void setup() {
 void loop() {
   if (sbus_rx.Read()) {
     /* Display the received data */
-    for (int i = 0; i < sbus_rx.rx_channels().size(); i++) {
+    for (uint8_t i = 0; i < sbus_rx.rx_channels().size(); i++) {
       Serial.print(sbus_rx.rx_channels()[i]);
       Serial.print("\t");
     }

--- a/src/sbus.cpp
+++ b/src/sbus.cpp
@@ -26,19 +26,15 @@
 #include "Arduino.h"
 #include "sbus.h"
 
-#ifdef ESP32
-SbusRx::SbusRx(HardwareSerial *bus, uint8_t rxpin, uint8_t txpin) {
-  bus_ = bus;
-  rxpin_ = rxpin;
-  txpin_ = txpin;
-}
-#else
 SbusRx::SbusRx(HardwareSerial *bus) {
   bus_ = bus;
 }
-#endif
 
+#ifdef ESP32
+void SbusRx::Begin(uint8_t rxpin, uint8_t txpin) {
+#else
 void SbusRx::Begin() {
+#endif
   parser_state_ = 0;
   previous_byte_ = SBUS_FOOTER_;
   /* Teensy 3.0 || Teensy 3.1/3.2 */
@@ -55,7 +51,7 @@ void SbusRx::Begin() {
     bus_->begin(BAUD_, SERIAL_SBUS);
   /* ESP32 */
   #elif defined(ESP32)
-    bus_->begin(BAUD_, SERIAL_8E2, rxpin_, txpin_, true);
+    bus_->begin(BAUD_, SERIAL_8E2, rxpin, txpin, true);
    /* Everything else, with a hardware inverter */
   #else
     bus_->begin(BAUD_, SERIAL_8E2);
@@ -149,19 +145,15 @@ namespace {
 }  // namespace
 #endif
 
-#ifdef ESP32
-SbusTx::SbusTx(HardwareSerial *bus, uint8_t rxpin, uint8_t txpin) {
-  bus_ = bus;
-  rxpin_ = rxpin;
-  txpin_ = txpin;
-}
-#else
 SbusTx::SbusTx(HardwareSerial *bus) {
   bus_ = bus;
 }
-#endif
 
+#ifdef ESP32
+void SbusTx::Begin(uint8_t rxpin, uint8_t txpin) {
+#else
 void SbusTx::Begin() {
+#endif
   /* Teensy 3.0 || Teensy 3.1/3.2 */
   #if defined(__MK20DX128__) || defined(__MK20DX256__)
     bus_->begin(BAUD_, SERIAL_8E1_RXINV_TXINV);
@@ -176,7 +168,7 @@ void SbusTx::Begin() {
     bus_->begin(BAUD_, SERIAL_SBUS);
   /* ESP32 */
   #elif defined(ESP32)
-    bus_->begin(BAUD_, SERIAL_8E2, rxpin_, txpin_, true);
+    bus_->begin(BAUD_, SERIAL_8E2, rxpin, txpin, true);
   /* Everything else, with a hardware inverter */
   #else
     bus_->begin(BAUD_, SERIAL_8E2);

--- a/src/sbus.h
+++ b/src/sbus.h
@@ -43,13 +43,14 @@ namespace sbus = std;
 class SbusRx {
  public:
 
-#ifdef ESP32
-  explicit SbusRx(HardwareSerial *bus, uint8_t rxpin, uint8_t txpin); // supports ESP32
-#else
   explicit SbusRx(HardwareSerial *bus);
+
+#ifdef ESP32
+  void Begin(uint8_t rxpin, uint8_t txpin);
+#else
+  void Begin();
 #endif
 
-  void Begin();
   bool Read();
   sbus::array<uint16_t, 16> rx_channels();
   inline bool failsafe() const {return failsafe_;}
@@ -60,11 +61,6 @@ class SbusRx {
  private:
   /* Communication */
   HardwareSerial *bus_;
-
-#ifdef ESP32
-  uint8_t rxpin_ = 0;
-  uint8_t txpin_ = 0;
-#endif
 
   static constexpr uint32_t BAUD_ = 100000;
   /* Parsing */
@@ -88,13 +84,14 @@ class SbusRx {
 class SbusTx {
  public:
 
-#ifdef ESP32
-  explicit SbusTx(HardwareSerial *bus, uint8_t rxpin, uint8_t txpin);
-#else
   explicit SbusTx(HardwareSerial *bus);
+
+#ifdef ESP32
+  void Begin(uint8_t rxpin, uint8_t txpin);
+#else
+  void Begin();
 #endif
 
-  void Begin();
   void Write();
   void failsafe(bool val) {failsafe_ = val;}
   void lost_frame(bool val) {lost_frame_ = val;}
@@ -110,11 +107,6 @@ class SbusTx {
  private:
   /* Communication */
   HardwareSerial *bus_;
-
-#ifdef ESP32
-  uint8_t rxpin_ = 0; 
-  uint8_t txpin_ = 0; 
-#endif
 
   static constexpr uint32_t BAUD_ = 100000;
   /* Parsing */


### PR DESCRIPTION
Sorry for the additional pull request; I should've added ESP32 support this way the first time! New API eliminates unnecessary instance variables and is more consistent with multi-platform Wire.begin().