### PR TITLE
fixed Parse overwritting buf_

### DIFF
--- a/src/sbus.cpp
+++ b/src/sbus.cpp
@@ -75,7 +75,7 @@ bool SbusRx::Read() {
     if (Parse()) {
       new_data_ = true;
     }
-  } while (uart_->available());
+  } while (uart_->available() && !new_data_);
   /* Parse new data, if available */
   if (new_data_) {
     /* Grab the channel data */

--- a/src/sbus.cpp
+++ b/src/sbus.cpp
@@ -37,7 +37,7 @@
 namespace bfs {
 
 #if defined(ESP32)
-void SbusRx::Begin(const int8_t rxpin, const int8_t txpin) {
+void SbusRx::Begin(const int8_t rxpin, const int8_t txpin, bool inverted=true) {
 #else
 void SbusRx::Begin() {
 #endif
@@ -60,7 +60,7 @@ void SbusRx::Begin() {
     uart_->begin(BAUD_, SERIAL_8E2 | 0xC000ul);
   /* ESP32 */
   #elif defined(ESP32)
-    uart_->begin(BAUD_, SERIAL_8E2, rxpin, txpin, true);
+    uart_->begin(BAUD_, SERIAL_8E2, rxpin, txpin, inverted);
   /* Everything else, with a hardware inverter */
   #else
     uart_->begin(BAUD_, SERIAL_8E2);
@@ -159,7 +159,7 @@ namespace {
 #endif
 
 #if defined(ESP32)
-void SbusTx::Begin(const int8_t rxpin, const int8_t txpin) {
+void SbusTx::Begin(const int8_t rxpin, const int8_t txpin, bool inverted=true) {
 #else
 void SbusTx::Begin() {
 #endif
@@ -182,7 +182,7 @@ void SbusTx::Begin() {
   uart_->begin(BAUD_, SERIAL_8E2 | 0xC000ul);
   /* ESP32 */
   #elif defined(ESP32)
-  uart_->begin(BAUD_, SERIAL_8E2, rxpin, txpin, true);
+  uart_->begin(BAUD_, SERIAL_8E2, rxpin, txpin, inverted);
   /* Everything else, with a hardware inverter */
   #else
   uart_->begin(BAUD_, SERIAL_8E2);

--- a/src/sbus.h
+++ b/src/sbus.h
@@ -69,7 +69,7 @@ class SbusRx {
  public:
   explicit SbusRx(HardwareSerial *bus) : uart_(bus) {}
   #if defined(ESP32)
-  void Begin(const int8_t rxpin, const int8_t txpin);
+  void Begin(const int8_t rxpin, const int8_t txpin, bool inverted);
   #else
   void Begin();
   #endif
@@ -106,7 +106,7 @@ class SbusTx {
  public:
   explicit SbusTx(HardwareSerial *bus) : uart_(bus) {}
   #if defined(ESP32)
-  void Begin(const int8_t rxpin, const int8_t txpin);
+  void Begin(const int8_t rxpin, const int8_t txpin, bool inverted);
   #else
   void Begin();
   #endif


### PR DESCRIPTION
If Parse() returns true, the while loop will still run once after(I am guessing because there is still data in the serial RX buffer), overwritting the buffer. 
This is a non issue under normal conditions, as it would just overwrite near identical data. 
However if the second byte is equal to the header (0x0F), Parse() will assume that second byte to be the footer. 
This is because the execution branch at the end does not do "prev_byte_ = curr_byte_", while still having set curr_byte_ to the current package, hence skipping the header in the evaluation.