### PR TITLE
Updated example to be compile compatible with ESP32 & README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note that lost frame is indicated when a frame is lost between the transmitter a
 
 A variation on SBUS called "Fast SBUS" has started to be used. This uses a baudrate of 200000 and a quicker update rate.
 
-A further variation is known as "M-Bus", found on Microzone Receivers (e.g. MC7RB v2 receiver, for use with the Microzone MC6C-M transmitter)
+A further variation is known as "M-Bus", found on Microzone Receivers (e.g. MC7RB v2 receiver, for use with the Microzone MC6C-M transmitter).  It operates at the same baudrate of 100000 as SBus, and also uses inverted serial logic.
 
 **Note on CH17 and CH18:** Channel 17 and channel 18 are digital on/off channels. These are not universally available on all SBUS receivers and servos.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Note that lost frame is indicated when a frame is lost between the transmitter a
 
 A variation on SBUS called "Fast SBUS" has started to be used. This uses a baudrate of 200000 and a quicker update rate.
 
+A further variation is known as "M-Bus", found on Microzone Receivers (e.g. MC7RB v2 receiver, for use with the Microzone MC6C-M transmitter)
+
 **Note on CH17 and CH18:** Channel 17 and channel 18 are digital on/off channels. These are not universally available on all SBUS receivers and servos.
 
 FrSky receivers will output a range of 172 - 1811 with channels set to a range of -100% to +100%. Using extended limits of -150% to +150% outputs a range of 0 to 2047, which is the maximum range acheivable with 11 bits of data.

--- a/examples/arduino/sbus_example/sbus_example.ino
+++ b/examples/arduino/sbus_example/sbus_example.ino
@@ -25,10 +25,22 @@
 
 #include "sbus.h"
 
+#if defined(ESP32)
+
+/* SBUS object, reading SBUS */
+bfs::SbusRx sbus_rx(&Serial2, 16, 17, true);
+/* SBUS object, writing SBUS */
+bfs::SbusTx sbus_tx(&Serial2, 16, 17, true);
+
+#else
+
 /* SBUS object, reading SBUS */
 bfs::SbusRx sbus_rx(&Serial2);
 /* SBUS object, writing SBUS */
 bfs::SbusTx sbus_tx(&Serial2);
+
+#endif
+
 /* SBUS data */
 bfs::SbusData data;
 


### PR DESCRIPTION
Updated example to work with ESP32 setup (the constructor is different, based on conditional compilation). 

Added to README.md to help discovery of this library for Microzone receiver users where it's called M-Bus (instead of SBus)

Original error message for the example running on the ESP32 was: 
```
C:\Users\myUser\Documents\Arduino\rc_receiver_mbus\sbus_example\sbus_example.ino:29:29: error: no matching function for call to 'bfs::SbusRx::SbusRx(HardwareSerial*)'
   29 | bfs::SbusRx sbus_rx(&Serial2);
      |                             ^
In file included from C:\Users\myUser\Documents\Arduino\rc_receiver_mbus\sbus_example\sbus_example.ino:26:
c:\Users\myUser\Documents\Arduino\libraries\Bolder_Flight_Systems_SBUS\src/sbus.h:53:3: note: candidate: 'bfs::SbusRx::SbusRx(HardwareSerial*, int8_t, int8_t, bool, bool)'
   53 |   SbusRx(HardwareSerial *bus, const int8_t rxpin, const int8_t txpin,
      |   ^~~~~~
c:\Users\myUser\Documents\Arduino\libraries\Bolder_Flight_Systems_SBUS\src/sbus.h:53:3: note:   candidate expects 5 arguments, 1 provided
c:\Users\myUser\Documents\Arduino\libraries\Bolder_Flight_Systems_SBUS\src/sbus.h:50:3: note: candidate: 'bfs::SbusRx::SbusRx(HardwareSerial*, int8_t, int8_t, bool)'
   50 |   SbusRx(HardwareSerial *bus, const int8_t rxpin, const int8_t txpin,
      |   ^~~~~~
c:\Users\myUser\Documents\Arduino\libraries\Bolder_Flight_Systems_SBUS\src/sbus.h:50:3: note:   candidate expects 4 arguments, 1 provided
c:\Users\myUser\Documents\Arduino\libraries\Bolder_Flight_Systems_SBUS\src/sbus.h:47:7: note: candidate: 'constexpr bfs::SbusRx::SbusRx(const bfs::SbusRx&)'
   47 | class SbusRx {
      |       ^~~~~~
c:\Users\myUser\Documents\Arduino\libraries\Bolder_Flight_Systems_SBUS\src/sbus.h:47:7: note:   no known conversion for argument 1 from 'HardwareSerial*' to 'const bfs::SbusRx&'
c:\Users\myUser\Documents\Arduino\libraries\Bolder_Flight_Systems_SBUS\src/sbus.h:47:7: note: candidate: 'constexpr bfs::SbusRx::SbusRx(bfs::SbusRx&&)'
c:\Users\myUser\Documents\Arduino\libraries\Bolder_Flight_Systems_SBUS\src/sbus.h:47:7: note:   no known conversion for argument 1 from 'HardwareSerial*' to 'bfs::SbusRx&&'

exit status 1

Compilation error: no matching function for call to 'bfs::SbusRx::SbusRx(HardwareSerial*)'
```