### PR TITLE
Add SoftwareSerial support for SBUS communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ bfs::SbusRx sbus(&Serial1, false);
 
 **(ESP32 ONLY) SbusRx(HardwareSerial &ast;bus, const int8_t rxpin, const int8_t txpin, const bool inv, const bool fast)** Same as the constructor above, but enables selecting the fast SBUS baudrate (200000) if *fast* is true.
 
+**SbusRx(AltSoftSerial &ast;bus)** Creates an *SbusRx* object. A pointer to the *AltSoftSerial* object corresponding to the software serial port used is passed. The RX pin of the software serial port will receive SBUS packets.
+
+```C++
+bfs::SbusRx sbus(&altSerial);
+```
+
+**SbusRx(AltSoftSerial &ast;bus, const bool inv)** Creates an *SbusRx* object. A pointer to the *AltSoftSerial* object corresponding to the software serial port used is passed along with a second parameter, *inv*, which sets whether inverted serial is used. If *inv* is true, the signal is the standard inverted SBUS, otherwise it is non-inverted SBUS.
+
+```C++
+bfs::SbusRx sbus(&altSerial, false);
+```
+
+**SbusRx(AltSoftSerial &ast;bus, const bool inv, const bool fast)** Same as the constructor above, but enables selecting the fast SBUS baudrate (200000) if *fast* is true.
+
 **void Begin()** Initializes SBUS communication.
 
 ```C++
@@ -157,7 +171,23 @@ bfs::SbusTx sbus(&Serial1);
 bfs::SbusTx sbus(&Serial1, false);
 ```
 
+**SbusTx(HardwareSerial &ast;bus, const bool inv, const bool fast)** Same as the constructor above, but enables selecting the fast SBUS baudrate (200000) if *fast* is true.
+
 **(ESP32 ONLY) SbusTx(HardwareSerial &ast;bus, const int8_t rxpin, const int8_t txpin, const bool inv)** Creates an *SbusTx* object. A pointer to the *Serial* object corresponding to the serial port used is passed along with the RX pin number (*rxpin*), TX pin number (*txpin*), and whether inverted serial is used (*inv*). If *inv* is true, the signal is the standard inverted SBUS, otherwise it is non-inverted SBUS.
+
+**SbusTx(AltSoftSerial &ast;bus)** Creates an *SbusTx* object. A pointer to the *AltSoftSerial* object corresponding to the software serial port used is passed. The TX pin of the software serial port will receive SBUS packets.
+
+```C++
+bfs::SbusTx sbus(&altSerial);
+```
+
+**SbusTx(AltSoftSerial &ast;bus, const bool inv)** Creates an *SbusTx* object. A pointer to the *AltSoftSerial* object corresponding to the software serial port used is passed along with a second parameter, *inv*, which sets whether inverted serial is used. If *inv* is true, the signal is the standard inverted SBUS, otherwise it is non-inverted SBUS.
+
+```C++
+bfs::SbusTx sbus(&altSerial, false);
+```
+
+**SbusTx(AltSoftSerial &ast;bus, const bool inv, const bool fast)** Same as the constructor above, but enables selecting the fast SBUS baudrate (200000) if *fast* is true.
 
 **void Begin()** Initializes SBUS communication.
 

--- a/examples/arduino/sbus_example/sbus_example.ino
+++ b/examples/arduino/sbus_example/sbus_example.ino
@@ -23,12 +23,16 @@
 * IN THE SOFTWARE.
 */
 
+#include <AltSoftSerial.h>
 #include "sbus.h"
 
+/* AltSoftSerial object for SBUS communication */
+AltSoftSerial altSerial;
+
 /* SBUS object, reading SBUS */
-bfs::SbusRx sbus_rx(&Serial2);
+bfs::SbusRx sbus_rx(&altSerial);
 /* SBUS object, writing SBUS */
-bfs::SbusTx sbus_tx(&Serial2);
+bfs::SbusTx sbus_tx(&altSerial);
 /* SBUS data */
 bfs::SbusData data;
 

--- a/src/sbus.h
+++ b/src/sbus.h
@@ -28,6 +28,7 @@
 
 #if defined(ARDUINO)
 #include <Arduino.h>
+#include <AltSoftSerial.h>
 #else
 #include <cstddef>
 #include <cstdint>
@@ -59,6 +60,11 @@ class SbusRx {
   SbusRx(HardwareSerial *bus, const bool inv, const bool fast) : uart_(bus),
                                                                  inv_(inv),
                                                                  fast_(fast) {}
+  explicit SbusRx(AltSoftSerial *bus) : soft_uart_(bus) {}
+  SbusRx(AltSoftSerial *bus, const bool inv) : soft_uart_(bus), inv_(inv) {}
+  SbusRx(AltSoftSerial *bus, const bool inv, const bool fast) : soft_uart_(bus),
+                                                                inv_(inv),
+                                                                fast_(fast) {}
   #endif
   void Begin();
   bool Read();
@@ -66,7 +72,8 @@ class SbusRx {
 
  private:
   /* Communication */
-  HardwareSerial *uart_;
+  HardwareSerial *uart_ = nullptr;
+  AltSoftSerial *soft_uart_ = nullptr;
   bool inv_ = true;
   bool fast_ = false;
   #if defined(ESP32)
@@ -113,6 +120,11 @@ class SbusTx {
   SbusTx(HardwareSerial *bus, const bool inv, const bool fast) : uart_(bus),
                                                                  inv_(inv),
                                                                  fast_(fast) {}
+  explicit SbusTx(AltSoftSerial *bus) : soft_uart_(bus) {}
+  SbusTx(AltSoftSerial *bus, const bool inv) : soft_uart_(bus), inv_(inv) {}
+  SbusTx(AltSoftSerial *bus, const bool inv, const bool fast) : soft_uart_(bus),
+                                                                inv_(inv),
+                                                                fast_(fast) {}
   #endif
   void Begin();
   void Write();
@@ -121,7 +133,8 @@ class SbusTx {
 
  private:
   /* Communication */
-  HardwareSerial *uart_;
+  HardwareSerial *uart_ = nullptr;
+  AltSoftSerial *soft_uart_ = nullptr;
   bool inv_ = true;
   bool fast_ = false;
   #if defined(ESP32)


### PR DESCRIPTION
Related to #69

Add support for `AltSoftSerial` for SBUS communication.

* **src/sbus.h**
  - Include the `AltSoftSerial` library.
  - Add constructors for `SbusRx` and `SbusTx` that accept `AltSoftSerial`.
  - Modify `SbusRx` and `SbusTx` classes to use `AltSoftSerial`.

* **src/sbus.cpp**
  - Include the `AltSoftSerial` library.
  - Modify the `Begin` method in `SbusRx` and `SbusTx` to initialize `AltSoftSerial`.
  - Modify the `Read` and `Write` methods in `SbusRx` and `SbusTx` to use `AltSoftSerial`.

* **examples/arduino/sbus_example/sbus_example.ino**
  - Include the `AltSoftSerial` library.
  - Modify the example to use `AltSoftSerial` for SBUS communication.

* **README.md**
  - Update instructions to include the use of `AltSoftSerial` for `SoftwareSerial` support.

